### PR TITLE
Fixes clear from noop-ing.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -99,12 +99,12 @@ export class StorageArea {
         // If the database failed to initialize, then that's fine, we'll still try to delete it.
       }
 
-      // _databasePromise.set(this, null);
-      this._databasePromise = null;
+      // this._databasePromise = null;
+      _databasePromise.set(this, null);
     }
 
-    // return promiseForRequest(self.indexedDB.deleteDatabase(_databaseName.get(this)));
-    return promiseForRequest(self.indexedDB.deleteDatabase(this._databaseName));
+    // return promiseForRequest(self.indexedDB.deleteDatabase(this._databaseName));
+    return promiseForRequest(self.indexedDB.deleteDatabase(_databaseName.get(this)));
   }
 
   keys () {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,7 @@
  * the License.
  */
 
-import { StorageArea, storage } from '../';
+import { StorageArea, storage } from '../src';
 
 async function collectAsyncIterator (asyncIterator) {
   const array = [];
@@ -23,8 +23,6 @@ async function collectAsyncIterator (asyncIterator) {
   }
   return array;
 }
-
-let counter = 0;
 
 console.log({ StorageArea, storage });
 
@@ -43,7 +41,7 @@ describe('StorageArea', () => {
 
   describe('StorageArea#set', () => {
     it('should allow setting a value', async () => {
-      area = new StorageArea(++counter);
+      area = new StorageArea('test_area');
 
       const result = await area.set('foo', 'bar');
       expect(result).not.toBeDefined();
@@ -55,7 +53,7 @@ describe('StorageArea', () => {
 
   describe('StorageArea#entries', () => {
     it('should be a thing', async () => {
-      area = new StorageArea(++counter);
+      area = new StorageArea('test_area');
 
       await area.set('mycat', 'Tom');
       await area.set('mydog', 'Jerry');
@@ -71,7 +69,7 @@ describe('StorageArea', () => {
 
   describe('StorageArea#delete', () => {
     it('should be a thing', async () => {
-      area = new StorageArea(++counter);
+      area = new StorageArea('test_area');
 
       await area.set('mycat', 'Tom');
       expect(await area.get('mycat')).toBe('Tom');


### PR DESCRIPTION
I was curious about that `weakMap`-as-private-property implementation so I dug a bit and it turns out `clear` is currently noop-ing because the currently uncommented implementation is the default property access one and not the one using `weakMap`s.

Tests aren't detecting it because they are all using different storage areas thanks to being initiated with `++counter`.

Also added a small commit to remove `backingStore` which was dead code / unusued afaics.