### PR TITLE
Make default storage area a default export

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "main": "dist/kv-storage-polyfill.js",
   "module": "dist/kv-storage-polyfill.mjs",
   "scripts": {
-    "build": "microbundle",
+    "build": "microbundle -f es && microbundle -f cjs,umd src/cjs.js",
     "test": "microbundle && MOZ_HEADLESS=1 karmatic --downlevel --browsers chrome:headless,firefox,sauce-ie-11-win10,sauce-edge-17-win10"
   },
   "keywords": [

--- a/src/cjs.js
+++ b/src/cjs.js
@@ -1,0 +1,21 @@
+/**
+ * Copyright 2019 Google LLC
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not
+ * use this file except in compliance with the License. You may obtain a copy of
+ * the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+ * WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+ * License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+// Simplify CommonJS and UMD consumption by flattening exports.
+import storage, { StorageArea } from './index.js';
+storage.default = storage;
+storage.StorageArea = StorageArea;
+export default storage;

--- a/src/index.js
+++ b/src/index.js
@@ -138,7 +138,7 @@ if (typeof Symbol === 'function' && Symbol.asyncIterator) {
   StorageArea.prototype[Symbol.asyncIterator] = StorageArea.prototype.entries;
 }
 
-export const storage = new StorageArea(DEFAULT_STORAGE_AREA_NAME);
+export default new StorageArea(DEFAULT_STORAGE_AREA_NAME);
 
 async function performDatabaseOperation (area, mode, steps) {
   // if (this._databasePromise === null) {

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -15,7 +15,7 @@
  */
 
 import './_helpers';
-import { StorageArea, storage } from '..';
+import storage, { StorageArea } from '..';
 // import { StorageArea, storage } from '../src';
 
 async function collectAsyncIterator (asyncIterator) {


### PR DESCRIPTION
As per WICG/kv-storage#71. Fixes #7.

Mixed named+default exports present problems in CommonJS and UMD bundles, so I've gone with a pragmatic solution proven in other libraries: the cjs and umd bundles merge named exports into the default export itself. This allows usage in Node, Webpack and Browserify to follow the ESM naming without requiring additional steps or documentation.

```js
// CommonJS Usage
const storage = require('kv-storage-polyfill');  // default export (handwritten/loose)
const storage = require('kv-storage-polyfill').default  // default export (cjs compat mode)
const { StorageArea } = require('kv-storage-polyfill');  // named export (all consumers)

// Similarly for UMD/AMD:
define(['/web/kv-storage-polyfill.umd.js'], function(storage) {
  storage === storage.default // default storage area
  storage.StorageArea
});

// ...as well as for globals
<script src="/web/kv-storage/polyfill.umd.js"></script>
<script>
  const { StorageArea } = kvStoragePolyfill;
  const storage = kvStoragePolyfill;  // optional `.default`
</script>
```

Note the mjs output does not include this compatibility shim, it follows spec.

/cc @domenic